### PR TITLE
Back Button on Settings Leaves Screen Blank

### DIFF
--- a/app/src/main/kotlin/com/bodyweight/fitness/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/bodyweight/fitness/ui/MainActivity.kt
@@ -30,7 +30,6 @@ class MainActivity : RxAppCompatActivity() {
         val fragmentTransaction = fragmentManager.beginTransaction()
 
         fragmentTransaction.replace(R.id.view_settings, SettingsFragment(), "SettingsFragment")
-        fragmentTransaction.addToBackStack(null)
         fragmentTransaction.commit()
 
         Stream.drawerObservable()


### PR DESCRIPTION
### Fix
Remove adding Settings fragment to the back stack.  Adding it to the back stack allows the back button to dismiss the fragment from the Settings screen leaving it blank.