### PR TITLE
Replace the pencil icon with check for logging

### DIFF
--- a/app/src/main/res/drawable/action_done_white.xml
+++ b/app/src/main/res/drawable/action_done_white.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
+</vector>

--- a/app/src/main/res/layout-port/view_timer.xml
+++ b/app/src/main/res/layout-port/view_timer.xml
@@ -81,7 +81,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        app:srcCompat="@drawable/action_log"
+                        app:srcCompat="@drawable/action_done_white"
                         android:layout_centerInParent="true"
                         app:borderWidth="0dp"
                         app:elevation="@dimen/view_action_elevation"/>

--- a/app/src/main/res/layout/view_timer.xml
+++ b/app/src/main/res/layout/view_timer.xml
@@ -81,7 +81,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        app:srcCompat="@drawable/action_log"
+                        app:srcCompat="@drawable/action_done_white"
                         android:layout_centerInParent="true"
                         app:borderWidth="0dp"
                         app:elevation="@dimen/view_action_elevation"/>


### PR DESCRIPTION
This implements one suggestion from @skmlcd and partially
addresses #44. Having the same icon on the screen twice with two different meanings (edit and create) was a bit confusing. The check symbolizes "done", as in, the user is done with this set, so log it.
![screen shot 2017-01-07 at 11 11 37 am](https://cloud.githubusercontent.com/assets/5114833/21743563/290e021c-d4ca-11e6-9c52-0499543fcff0.png)
